### PR TITLE
Optimize fitting

### DIFF
--- a/bayesDREAM/core.py
+++ b/bayesDREAM/core.py
@@ -811,7 +811,21 @@ class _BayesDREAMCore(PlottingMixin):
             # Weights for NTC mean = cells_per_guide, matching fit_cis.
 
             guide_assignment = self.guide_assignment  # (n_cells, n_guides)
-            is_ntc_guide = (self.guide_meta['target'] == 'ntc').values  # (n_guides,)
+
+            # Determine which guides are NTC — works for both guide_meta['target'] and guide_targets_dict
+            _ntc_variants = {'ntc', 'NTC', 'non-targeting', 'non-targeting-control', 'Non-Targeting'}
+            if 'target' in self.guide_meta.columns:
+                is_ntc_guide = self.guide_meta['target'].isin(_ntc_variants).values
+            elif hasattr(self, 'guide_targets_dict') and self.guide_targets_dict:
+                is_ntc_guide = np.array([
+                    any(t in _ntc_variants for t in self.guide_targets_dict.get(row['guide'], []))
+                    for _, row in self.guide_meta.iterrows()
+                ])
+            else:
+                raise ValueError(
+                    "adjust_ntc_sum_factor (high MOI): cannot identify NTC guides — "
+                    "guide_meta has no 'target' column and guide_targets_dict is unavailable."
+                )
 
             log_sf = np.log(meta_out[sum_factor_col_old].values.astype(float))
             log_sf_adj = log_sf.copy()

--- a/bayesDREAM/core.py
+++ b/bayesDREAM/core.py
@@ -148,27 +148,14 @@ class _BayesDREAMCore(PlottingMixin):
         # Handle counts - can be DataFrame or sparse matrix
         self.is_sparse_counts = sparse.issparse(counts)
         if self.is_sparse_counts:
-            # Keep sparse matrix as-is
             self.counts = counts.copy() if hasattr(counts, 'copy') else counts.tocsr()
-            # Extract gene and cell names from DataFrame metadata
-            if isinstance(counts, pd.DataFrame):
-                self._gene_names = counts.index.tolist()
-                self._cell_names = counts.columns.tolist()
-            else:
-                # counts is sparse array - will extract names from gene_meta and meta later
-                self._gene_names = None
-                self._cell_names = None
-            pass  # sparse matrix stored as-is
+            self._cell_names = counts.columns.tolist() if isinstance(counts, pd.DataFrame) else None
         else:
-            # DataFrame or dense array
             if isinstance(counts, pd.DataFrame):
                 self.counts = counts.copy()
-                self._gene_names = counts.index.tolist()
                 self._cell_names = counts.columns.tolist()
             else:
-                # Dense numpy array - store as-is, extract names later
                 self.counts = counts.copy() if hasattr(counts, 'copy') else counts
-                self._gene_names = None
                 self._cell_names = None
 
         self.cis_gene = cis_gene
@@ -291,110 +278,6 @@ class _BayesDREAMCore(PlottingMixin):
 
         else:
             self.is_high_moi = False
-
-        # Handle gene metadata and extract gene names
-        if gene_meta is None:
-            # Create minimal gene metadata from counts
-            if isinstance(counts, pd.DataFrame):
-                # DataFrame: use string index from DataFrame
-                gene_names = counts.index.tolist()
-                self.gene_meta = pd.DataFrame({
-                    'gene': gene_names
-                }, index=gene_names)
-                self._gene_names = gene_names
-            else:
-                # Matrix/array: use NUMERIC index [0, 1, 2, ...]
-                n_features = counts.shape[0]
-                self.gene_meta = pd.DataFrame({
-                    'feature_id': range(n_features)
-                }, index=range(n_features))
-                self._gene_names = None  # No string names for matrices
-        else:
-            # Validate and process provided gene_meta
-            gene_meta = gene_meta.copy()
-
-            # Check that gene_meta has at least one identifier column
-            has_gene_col = 'gene' in gene_meta.columns
-            has_gene_name = 'gene_name' in gene_meta.columns
-            has_gene_id = 'gene_id' in gene_meta.columns
-            has_feature_id = 'feature_id' in gene_meta.columns
-
-            if not has_gene_col and not has_gene_name and not has_gene_id and not has_feature_id:
-                raise ValueError(
-                    "gene_meta must have at least one identifier column: "
-                    "'gene', 'gene_name', 'gene_id', or 'feature_id'"
-                )
-
-            # Handle based on counts type
-            if isinstance(counts, pd.DataFrame):
-                # DataFrame: gene_meta should use same string index as counts
-                # Ensure we have a 'gene' column for internal use
-                if not has_gene_col:
-                    if gene_meta.index.name is not None:
-                        gene_meta['gene'] = gene_meta.index
-                    elif has_gene_name:
-                        gene_meta['gene'] = gene_meta['gene_name']
-                    elif has_gene_id:
-                        gene_meta['gene'] = gene_meta['gene_id']
-
-                counts_gene_names = counts.index.tolist()
-
-                # Ensure gene_meta index matches counts index
-                if not gene_meta.index.equals(pd.Index(counts_gene_names)):
-                    # Try to reindex by matching identifiers
-                    if set(counts_gene_names).issubset(set(gene_meta.index)):
-                        gene_meta = gene_meta.loc[counts_gene_names]
-                    else:
-                        warnings.warn(
-                            f"[WARNING] gene_meta index does not match counts index. "
-                            f"Attempting to match by identifier columns.",
-                            UserWarning
-                        )
-                        # Try matching by columns
-                        matched_indices = []
-                        for gene in counts_gene_names:
-                            found = False
-                            for col in ['gene', 'gene_name', 'gene_id']:
-                                if col in gene_meta.columns and gene in gene_meta[col].values:
-                                    matched_indices.append(gene_meta[gene_meta[col] == gene].index[0])
-                                    found = True
-                                    break
-                            if not found:
-                                # Add minimal metadata for missing gene
-                                matched_indices.append(gene)
-
-                        # Add any missing genes
-                        missing = set(counts_gene_names) - set(gene_meta.index)
-                        if missing:
-                            missing_df = pd.DataFrame({'gene': list(missing)}, index=list(missing))
-                            gene_meta = pd.concat([gene_meta, missing_df])
-
-                        gene_meta = gene_meta.loc[counts_gene_names]
-
-                self._gene_names = counts_gene_names
-            else:
-                # Matrix/array: ensure gene_meta has NUMERIC index [0, 1, 2, ...]
-                n_features = counts.shape[0]
-
-                # Check if gene_meta already has numeric index of correct length
-                if isinstance(gene_meta.index, pd.RangeIndex) and len(gene_meta) == n_features:
-                    # Already has correct numeric index
-                    pass
-                elif all(isinstance(idx, (int, np.integer)) for idx in gene_meta.index) and len(gene_meta) == n_features:
-                    # Has integer index - ensure it's a proper range
-                    gene_meta.index = range(n_features)
-                else:
-                    # Reset to numeric index
-                    if len(gene_meta) != n_features:
-                        raise ValueError(
-                            f"gene_meta has {len(gene_meta)} rows but counts has {n_features} features. "
-                            f"For matrix/array counts, gene_meta must have exactly {n_features} rows."
-                        )
-                    gene_meta.index = range(n_features)
-
-                self._gene_names = None  # No string names for matrices
-
-            self.gene_meta = gene_meta
 
         # Ensure guide_covariates and guide_covariates_ntc are always lists
         if guide_covariates is None:
@@ -620,80 +503,31 @@ class _BayesDREAMCore(PlottingMixin):
         detected_mask = gene_sums > 0
         num_removed = (~detected_mask).sum()
 
-        # Raise error if cis gene is undetected
-        if self.cis_gene is not None:
-            if isinstance(self.counts, pd.DataFrame):
-                # DataFrame: check if cis_gene is in index
-                if self.cis_gene not in self.counts.index:
-                    raise ValueError(f"[ERROR] The cis gene '{self.cis_gene}' not found in counts index!")
-                cis_idx = self.counts.index.get_loc(self.cis_gene)
-            else:
-                # Matrix/array: search gene_meta columns for cis_gene
-                # Try columns in order: gene_name, gene, gene_id, feature_id
-                cis_idx = None
-                for col in ['gene_name', 'gene', 'gene_id', 'feature_id']:
-                    if col in self.gene_meta.columns:
-                        matches = self.gene_meta[self.gene_meta[col] == self.cis_gene]
-                        if len(matches) > 0:
-                            # Found cis gene - use its numeric index for validation
-                            cis_idx = matches.index[0]
-                            break
-
-                if cis_idx is None:
-                    available_cols = [c for c in ['gene_name', 'gene', 'gene_id', 'feature_id'] if c in self.gene_meta.columns]
-                    raise ValueError(
-                        f"[ERROR] The cis gene '{self.cis_gene}' not found in gene_meta columns {available_cols}!"
-                    )
-
-            # Check if cis gene has zero counts
+        # Cis gene existence and zero-variance are already validated by _extract_cis_from_gene
+        # (called in bayesDREAM.__init__ before super().__init__).
+        # For DataFrame counts only: double-check the gene is still in the index after cell subsetting.
+        if self.cis_gene is not None and isinstance(self.counts, pd.DataFrame):
+            if self.cis_gene not in self.counts.index:
+                raise ValueError(f"[ERROR] The cis gene '{self.cis_gene}' not found in counts index!")
+            cis_idx = self.counts.index.get_loc(self.cis_gene)
             if not detected_mask[cis_idx]:
                 raise ValueError(f"[ERROR] The cis gene '{self.cis_gene}' has zero counts after subsetting!")
 
-        # Subset counts to detected genes only - works for DataFrame, dense, and sparse
+        # Subset counts to detected genes only (counts freed at end of init; used for cell alignment below)
         if isinstance(self.counts, pd.DataFrame):
             self.counts = self.counts.loc[detected_mask]
-            self._gene_names = self.counts.index.tolist()
-            self.gene_meta = self.gene_meta.loc[self._gene_names]
         else:
-            # Sparse or dense array - subset by row indices
             gene_indices = np.where(detected_mask)[0]
-            if self.is_sparse_counts:
-                self.counts = self.counts[gene_indices, :]
-            else:
-                self.counts = self.counts[gene_indices, :]
+            self.counts = self.counts[gene_indices, :]
 
-            # Subset gene_meta by numeric indices
-            self.gene_meta = self.gene_meta.iloc[gene_indices].copy()
-
-            # CRITICAL: Reset index to [0, 1, 2, ..., n_remaining-1]
-            # This ensures row i in counts corresponds to row i in gene_meta
-            self.gene_meta.index = range(len(self.gene_meta))
-
-            # _gene_names remains None for matrices
-            self._gene_names = None
-
-        # Set trans genes
-        if isinstance(self.counts, pd.DataFrame):
-            # DataFrame: use string names
-            self.trans_genes = [g for g in self._gene_names if g != self.cis_gene]
+        # Set trans_genes from the primary modality (created in bayesDREAM.__init__ before super())
+        if hasattr(self, 'primary_modality') and self.primary_modality in getattr(self, 'modalities', {}):
+            gene_mod = self.modalities[self.primary_modality]
+            self.trans_genes = (gene_mod.feature_names
+                                if gene_mod.feature_names
+                                else list(range(gene_mod.dims['n_features'])))
         else:
-            # Matrix/array: trans_genes is list of numeric indices excluding cis
-            # Find which row has the cis gene after filtering
-            cis_row_after_filter = None
-            if self.cis_gene is not None:
-                for col in ['gene_name', 'gene', 'gene_id', 'feature_id']:
-                    if col in self.gene_meta.columns:
-                        matches = self.gene_meta[self.gene_meta[col] == self.cis_gene]
-                        if len(matches) > 0:
-                            cis_row_after_filter = matches.index[0]
-                            break
-
-            if cis_row_after_filter is not None:
-                # trans_genes = all indices except cis row
-                self.trans_genes = [i for i in range(len(self.gene_meta)) if i != cis_row_after_filter]
-            else:
-                # No cis gene - all rows are trans
-                self.trans_genes = list(range(len(self.gene_meta)))
+            self.trans_genes = []
 
         # zero-count genes removed here from self.counts; Modality.__init__ reports its own filtering
         
@@ -760,6 +594,11 @@ class _BayesDREAMCore(PlottingMixin):
         # Import here to avoid circular dependency
         from .io.summary import ModelSummarizer
         self._summarizer = ModelSummarizer(self)
+
+        # Free the raw counts matrix – data now lives in modalities.
+        # After all init logic above has consumed self.counts, drop it to save RAM.
+        self.counts = None
+        self.is_sparse_counts = None  # no longer meaningful without the matrix
 
         pass  # init summary printed by bayesDREAM.__init__ after modality setup
 
@@ -876,7 +715,7 @@ class _BayesDREAMCore(PlottingMixin):
         """
         Sets x_true as a point estimate with shape [N] (one value per cell).
         """
-        N = self.counts.shape[1]
+        N = len(self.meta)
         x_true = sample_or_use_point("x_true_posterior", x_true, self.device)
         if not (x_true.ndim == 1 and x_true.shape[0] == N):
             raise ValueError(
@@ -1428,158 +1267,128 @@ class _BayesDREAMCore(PlottingMixin):
             
         print("Running gene permutation...")
 
-        # If genes2permute is 'All', include all genes except the cis_gene
+        # --- Use modality counts directly ---
+        gene_mod = self.get_modality(self.primary_modality)
+        cis_mod  = self.get_modality('cis') if 'cis' in self.modalities else None
+
+        # Build feature-name → row-index lookup for the gene modality
+        feature_names = gene_mod.feature_names  # list[str] or None
+        if feature_names:
+            feat_name_to_idx = {name: idx for idx, name in enumerate(feature_names)}
+        else:
+            feat_name_to_idx = None
+
+        # If genes2permute is 'All', permute every trans gene
         if genes2permute == 'All' or genes2permute == ['All']:
-            if isinstance(self.counts, pd.DataFrame):
-                genes2permute = list(self.counts.index.values[self.counts.index.values != self.cis_gene])
-            else:
-                # For matrices/arrays: use self.trans_genes (already computed as numeric indices)
-                genes2permute = self.trans_genes.copy()
+            genes2permute = feature_names if feature_names else list(range(gene_mod.dims['n_features']))
 
         if isinstance(genes2permute, str):
             genes2permute = [genes2permute]
 
         meta_sub = self.meta.copy()
 
-        # Handle counts copying based on type
-        if isinstance(self.counts, pd.DataFrame):
-            counts_sub = self.counts.copy()
-        elif self.is_sparse_counts:
-            counts_sub = self.counts.copy()
-        else:
-            counts_sub = self.counts.copy()
+        # Copy gene modality counts for in-place modification
+        counts_sub = gene_mod.counts.copy()
 
-        # Create cell name to column index mapping for matrices/arrays
-        if isinstance(self.counts, pd.DataFrame):
-            cell_to_col_idx = {cell: idx for idx, cell in enumerate(counts_sub.columns)}
-        else:
-            cell_to_col_idx = {cell: idx for idx, cell in enumerate(self._cell_names)}
+        # Cell-name → column-index mapping (uses modality cell ordering)
+        cell_to_col_idx = {cell: idx for idx, cell in enumerate(gene_mod.cell_names)}
+
+        _is_sparse = sparse.issparse(counts_sub)
 
         for gene in genes2permute:
-            # Check if gene exists - works for both DataFrame and arrays
-            if isinstance(self.counts, pd.DataFrame):
-                if gene not in counts_sub.index:
+            # Resolve gene → row index in counts_sub
+            if feat_name_to_idx is not None and isinstance(gene, str):
+                if gene not in feat_name_to_idx:
                     continue
-                gene_idx = gene  # Use gene name directly for DataFrame
+                gene_row = feat_name_to_idx[gene]
+            elif isinstance(gene, int):
+                if gene >= gene_mod.dims['n_features']:
+                    continue
+                gene_row = gene
             else:
-                # For matrices/arrays: gene is a numeric index
-                if gene >= counts_sub.shape[0]:
-                    continue
-                gene_idx = gene  # Use numeric index directly
+                continue
 
-            for cov_values, group in meta_sub.groupby(covariates):
-                mycells = group.loc[group["target"] != "ntc", "cell"]
+            for _cov_values, group in meta_sub.groupby(covariates):
+                mycells     = group.loc[group["target"] != "ntc", "cell"]
                 my_ntc_cells = group.loc[group["target"] == "ntc", "cell"]
 
                 if len(mycells) > 0 and len(my_ntc_cells) > 0:
-                    # Get column indices for cells
-                    mycell_indices = [cell_to_col_idx[cell] for cell in mycells]
-                    my_ntc_indices = [cell_to_col_idx[cell] for cell in my_ntc_cells]
+                    mycell_indices   = [cell_to_col_idx[c] for c in mycells   if c in cell_to_col_idx]
+                    my_ntc_indices   = [cell_to_col_idx[c] for c in my_ntc_cells if c in cell_to_col_idx]
 
-                    # Get count data - works for DataFrame, dense, and sparse
-                    if isinstance(self.counts, pd.DataFrame):
-                        gene_counts_ntc = counts_sub.loc[gene_idx, my_ntc_cells].values
-                    elif self.is_sparse_counts:
-                        # Sparse: extract row, convert to dense array
-                        gene_counts_ntc = np.array(counts_sub[gene_idx, my_ntc_indices].todense()).flatten()
+                    if _is_sparse:
+                        gene_counts_ntc = np.asarray(counts_sub[gene_row, my_ntc_indices].todense()).flatten()
                     else:
-                        # Dense array
-                        gene_counts_ntc = counts_sub[gene_idx, my_ntc_indices]
+                        gene_counts_ntc = counts_sub[gene_row, my_ntc_indices]
 
-                    # Get sum factors from modality
-                    ntc_sum_factors = primary_mod.sum_factors.loc[my_ntc_cells.values, sum_factor_col].values
-                    mycell_sum_factors = primary_mod.sum_factors.loc[mycells.values, sum_factor_col].values
+                    ntc_sum_factors    = primary_mod.sum_factors.loc[my_ntc_cells.values, sum_factor_col].values
+                    mycell_sum_factors = primary_mod.sum_factors.loc[mycells.values,      sum_factor_col].values
 
-                    # Sample values from NTC distribution
                     sampled_values = np.random.choice(
                         gene_counts_ntc / ntc_sum_factors,
                         size=len(mycells),
                         replace=True
                     ) * mycell_sum_factors
 
-                    # Assign back to counts - works for DataFrame, dense, and sparse
-                    if isinstance(self.counts, pd.DataFrame):
-                        counts_sub.loc[gene_idx, mycells] = np.round(sampled_values)
-                    elif self.is_sparse_counts:
-                        # For sparse: convert to LIL format for efficient assignment
+                    if _is_sparse:
                         counts_sub = counts_sub.tolil()
-                        for i, cell_idx in enumerate(mycell_indices):
-                            counts_sub[gene_idx, cell_idx] = np.round(sampled_values[i])
+                        for i, col_idx in enumerate(mycell_indices):
+                            counts_sub[gene_row, col_idx] = np.round(sampled_values[i])
                         counts_sub = counts_sub.tocsr()
+                        _is_sparse = True  # still sparse
                     else:
-                        # Dense array
-                        counts_sub[gene_idx, mycell_indices] = np.round(sampled_values)
+                        counts_sub[gene_row, mycell_indices] = np.round(sampled_values)
 
-        if permute_ntc_x:
-            # Find cis gene index
-            if isinstance(self.counts, pd.DataFrame):
-                cis_gene_idx = self.cis_gene
-            else:
-                # For matrices/arrays: find cis gene row
-                cis_gene_idx = None
-                for col in ['gene_name', 'gene', 'gene_id', 'feature_id']:
-                    if col in self.gene_meta.columns:
-                        matches = self.gene_meta[self.gene_meta[col] == self.cis_gene]
-                        if len(matches) > 0:
-                            cis_gene_idx = matches.index[0]
-                            break
-                if cis_gene_idx is None:
-                    raise ValueError(f"Cannot find cis gene '{self.cis_gene}' for permutation")
+        if permute_ntc_x and cis_mod is not None:
+            cis_counts_sub = cis_mod.counts.copy()
+            cis_is_sparse  = sparse.issparse(cis_counts_sub)
+            cis_row = 0  # cis modality has exactly 1 feature row
 
-            for cov_values, group in meta_sub.groupby(covariates):
+            cis_cell_to_col = {cell: idx for idx, cell in enumerate(cis_mod.cell_names)}
+
+            for _cov_values, group in meta_sub.groupby(covariates):
                 my_ntc_cells = group.loc[group["target"] == "ntc", "cell"]
 
                 if len(my_ntc_cells) > 0:
-                    # Get column indices for NTC cells
-                    my_ntc_indices = [cell_to_col_idx[cell] for cell in my_ntc_cells]
+                    my_ntc_indices = [cis_cell_to_col[c] for c in my_ntc_cells if c in cis_cell_to_col]
 
-                    # Get sum factors from modality
                     ntc_sum_factor = primary_mod.sum_factors.loc[my_ntc_cells.values, sum_factor_col].values
 
-                    # Get cis gene expression for NTC cells
-                    if isinstance(self.counts, pd.DataFrame):
-                        ntc_expr = counts_sub.loc[cis_gene_idx, my_ntc_cells].values
-                    elif self.is_sparse_counts:
-                        ntc_expr = np.array(counts_sub[cis_gene_idx, my_ntc_indices].todense()).flatten()
+                    if cis_is_sparse:
+                        ntc_expr = np.asarray(cis_counts_sub[cis_row, my_ntc_indices].todense()).flatten()
                     else:
-                        ntc_expr = counts_sub[cis_gene_idx, my_ntc_indices]
+                        ntc_expr = np.asarray(cis_counts_sub)[cis_row, my_ntc_indices]
 
-                    ntc_expr_norm = ntc_expr / ntc_sum_factor
-
-                    # Sample indices with replacement
+                    ntc_expr_norm    = ntc_expr / ntc_sum_factor
                     permuted_indices = np.random.choice(len(my_ntc_cells), size=len(my_ntc_cells), replace=True)
+                    new_counts       = ntc_expr_norm[permuted_indices] * ntc_sum_factor
 
-                    # Permute counts
-                    new_counts = ntc_expr_norm[permuted_indices] * ntc_sum_factor
-
-                    # Assign back
-                    if isinstance(self.counts, pd.DataFrame):
-                        counts_sub.loc[cis_gene_idx, my_ntc_cells] = np.round(new_counts)
-                    elif self.is_sparse_counts:
-                        counts_sub = counts_sub.tolil()
-                        for i, cell_idx in enumerate(my_ntc_indices):
-                            counts_sub[cis_gene_idx, cell_idx] = np.round(new_counts[i])
-                        counts_sub = counts_sub.tocsr()
+                    if cis_is_sparse:
+                        cis_counts_sub = cis_counts_sub.tolil()
+                        for i, col_idx in enumerate(my_ntc_indices):
+                            cis_counts_sub[cis_row, col_idx] = np.round(new_counts[i])
+                        cis_counts_sub = cis_counts_sub.tocsr()
                     else:
-                        counts_sub[cis_gene_idx, my_ntc_indices] = np.round(new_counts)
-        
-                    # Permute x_true in the same order
+                        cis_counts_sub = np.asarray(cis_counts_sub)
+                        cis_counts_sub[cis_row, my_ntc_indices] = np.round(new_counts)
+
+                    # Permute x_true for NTC cells in the same order
                     ntc_idx = meta_sub.index[meta_sub["cell"].isin(my_ntc_cells)].tolist()
-                    assert len(ntc_idx) == len(my_ntc_cells)  # Sanity check
-        
-                    # Apply permutation to x_true
+                    assert len(ntc_idx) == len(my_ntc_cells)
+
                     if isinstance(self.x_true, torch.Tensor):
                         x_true_np = self.x_true.detach().cpu().numpy()
                     else:
                         x_true_np = np.array(self.x_true)
-        
+
                     x_true_ntc = x_true_np[ntc_idx]
                     x_true_np[ntc_idx] = x_true_ntc[permuted_indices]
-        
-                    # Assign back
                     self.x_true = torch.tensor(x_true_np, dtype=self.x_true.dtype, device=self.x_true.device)
 
-        self.counts = counts_sub
+            cis_mod.counts = cis_counts_sub
+
+        # Write permuted counts back into the modality
+        gene_mod.counts = counts_sub
 
     def subset_cells(
         self,
@@ -1653,16 +1462,49 @@ class _BayesDREAMCore(PlottingMixin):
 
         print(f"[INFO] Subsetting from {len(self.meta)} to {len(meta_subset)} cells")
 
-        # Subset counts
-        if isinstance(self.counts, pd.DataFrame):
-            counts_subset = self.counts[cells_to_keep].copy()
+        # Subset counts — reconstruct from modalities (self.counts is None after init)
+        cells_to_keep_set = set(cells_to_keep)
+        gene_mod = self.get_modality(self.primary_modality)
+        cis_mod  = self.get_modality('cis') if 'cis' in self.modalities else None
+
+        # Get column indices in the gene modality matching cells_to_keep
+        if gene_mod.cell_names:
+            gene_cell_indices = [i for i, c in enumerate(gene_mod.cell_names) if c in cells_to_keep_set]
         else:
-            # Sparse or dense array - subset by column indices
-            cell_indices = [i for i, cell in enumerate(self._cell_names) if cell in cells_to_keep]
-            if self.is_sparse_counts:
-                counts_subset = self.counts[:, cell_indices]
+            gene_cell_indices = [i for i, cell in enumerate(self.meta['cell']) if cell in cells_to_keep_set]
+
+        gene_counts_sub  = gene_mod.counts[:, gene_cell_indices]
+        gene_feat_meta   = gene_mod.feature_meta.copy() if gene_mod.feature_meta is not None else None
+
+        if cis_mod is not None:
+            if cis_mod.cell_names:
+                cis_cell_indices = [i for i, c in enumerate(cis_mod.cell_names) if c in cells_to_keep_set]
             else:
-                counts_subset = self.counts[:, cell_indices]
+                cis_cell_indices = gene_cell_indices
+
+            cis_counts_row = cis_mod.counts[:, cis_cell_indices]   # shape [1, N_sub]
+            cis_feat_meta  = cis_mod.feature_meta.copy()
+
+            # Stack: cis row first (row 0), then gene rows
+            if sparse.issparse(gene_counts_sub):
+                cis_sp       = (cis_counts_row.tocsr() if sparse.issparse(cis_counts_row)
+                                else sparse.csr_matrix(np.asarray(cis_counts_row).reshape(1, -1)))
+                counts_subset = sparse.vstack([cis_sp, gene_counts_sub], format='csr')
+            else:
+                cis_dense     = np.asarray(cis_counts_row).reshape(1, -1)
+                counts_subset = np.vstack([cis_dense, np.asarray(gene_counts_sub)])
+
+            # Build combined feature_meta with sequential 0-based index
+            # (constructor's _extract_cis_from_gene searches this by value, not position)
+            cis_fm  = cis_feat_meta.copy();  cis_fm.index  = [0]
+            if gene_feat_meta is not None:
+                gene_fm = gene_feat_meta.copy(); gene_fm.index = range(1, 1 + len(gene_feat_meta))
+                feature_meta_subset = pd.concat([cis_fm, gene_fm], ignore_index=True)
+            else:
+                feature_meta_subset = cis_fm
+        else:
+            counts_subset       = gene_counts_sub
+            feature_meta_subset = gene_feat_meta
 
         # Subset high MOI guide_assignment if applicable
         guide_assignment_subset = None
@@ -1689,7 +1531,7 @@ class _BayesDREAMCore(PlottingMixin):
             meta=meta_subset,
             counts=counts_subset,
             modality_name=self.primary_modality,  # Use same primary modality name
-            feature_meta=self.gene_meta.copy() if hasattr(self, 'gene_meta') else None,
+            feature_meta=feature_meta_subset,
             cis_gene=self.cis_gene,
             guide_covariates=self.guide_covariates,  # Preserve guide covariates
             guide_covariates_ntc=self.guide_covariates_ntc,  # Preserve NTC guide covariates

--- a/bayesDREAM/fitting/cis.py
+++ b/bayesDREAM/fitting/cis.py
@@ -165,11 +165,8 @@ class CisFitter:
             # This is always finite since x_eff_g > 0 and NTC_mean > 0.
 
             # NTC reference: weighted mean of NTC guide effects
-            ntc_mask = torch.tensor(
-                [self.model.guide_meta.iloc[g]['target'] == 'ntc' for g in range(x_eff_g.shape[-1])],
-                dtype=torch.bool,
-                device=self.model.device
-            )
+            # Use pre-computed mask (set in fit_cis before SVI loop to avoid pandas access here)
+            ntc_mask = self.model._ntc_guide_mask
             cells_per_guide = self.model.guide_assignment_tensor.sum(dim=0)  # [G]
             weights = cells_per_guide / sigma_eff.clamp(min=1e-6)            # [G]
             ntc_weights = weights[ntc_mask]
@@ -624,6 +621,25 @@ class CisFitter:
                 return sigma_eff_mean_tensor.clamp(min=1e-2).expand(G)
         
             return pyro.infer.autoguide.initialization.init_to_median(site)
+
+        # Pre-compute NTC guide mask for high MOI mode (avoids pandas access inside Pyro model)
+        if self.model.is_high_moi:
+            _ntc_variants = {'ntc', 'NTC', 'non-targeting', 'non-targeting-control', 'Non-Targeting'}
+            if 'target' in self.model.guide_meta.columns:
+                ntc_flags = [self.model.guide_meta.iloc[g]['target'] in _ntc_variants
+                             for g in range(G)]
+            elif hasattr(self.model, 'guide_targets_dict') and self.model.guide_targets_dict:
+                ntc_flags = [
+                    any(t in _ntc_variants for t in self.model.guide_targets_dict.get(row['guide'], []))
+                    for _, row in self.model.guide_meta.iterrows()
+                ]
+            else:
+                raise ValueError(
+                    "High MOI mode requires either guide_meta['target'] or guide_targets_dict "
+                    "to identify NTC guides."
+                )
+            self.model._ntc_guide_mask = torch.tensor(ntc_flags, dtype=torch.bool,
+                                                       device=self.model.device)
 
         guide_x = pyro.infer.autoguide.AutoNormalMessenger(self._model_x, init_loc_fn=init_loc_fn)
         guide_x.to(self.model.device)

--- a/bayesDREAM/fitting/cis.py
+++ b/bayesDREAM/fitting/cis.py
@@ -480,15 +480,35 @@ class CisFitter:
 
             ### BUILD target_per_guide_tensor [G] based on guide → target
             if self.model.is_high_moi:
-                # High MOI: use guide_meta to get target for each guide
-                # guide_meta has 'target' column, and guides are in order by guide_code
-                if 'target' not in self.model.guide_meta.columns:
-                    raise ValueError("independent_mu_sigma is True, but guide_meta missing 'target' column.")
+                # High MOI: derive one target label per guide for grouping mu/sigma.
+                # Two sources: guide_meta['target'] (simple) or guide_targets_dict (many-to-many).
+                _ntc_variants = {'ntc', 'NTC', 'non-targeting', 'non-targeting-control', 'Non-Targeting'}
 
-                # Factorize targets to get unique target codes
-                target_factorized, target_unique = pd.factorize(self.model.guide_meta['target'])
+                if 'target' in self.model.guide_meta.columns:
+                    guide_target_labels = self.model.guide_meta['target'].tolist()
+                elif hasattr(self.model, 'guide_targets_dict') and self.model.guide_targets_dict:
+                    # Derive a single representative target per guide.
+                    # Priority: cis_gene > any NTC variant > first target.
+                    def _primary_target(targets):
+                        if self.model.cis_gene and self.model.cis_gene in targets:
+                            return self.model.cis_gene
+                        for t in targets:
+                            if t in _ntc_variants:
+                                return 'ntc'
+                        return targets[0] if targets else 'ntc'
+
+                    guide_target_labels = [
+                        _primary_target(self.model.guide_targets_dict.get(row['guide'], ['ntc']))
+                        for _, row in self.model.guide_meta.iterrows()
+                    ]
+                else:
+                    raise ValueError(
+                        "independent_mu_sigma=True in high MOI mode requires either "
+                        "guide_meta['target'] or guide_targets_dict."
+                    )
+
+                target_factorized, target_unique = pd.factorize(guide_target_labels)
                 target_per_guide_tensor = torch.tensor(target_factorized, dtype=torch.long, device=self.model.device)
-
                 print(f"[INFO] independent_mu_sigma (high MOI): {len(target_unique)} unique targets")
             else:
                 # Single-guide mode: use existing logic

--- a/bayesDREAM/fitting/cis.py
+++ b/bayesDREAM/fitting/cis.py
@@ -325,12 +325,15 @@ class CisFitter:
         if isinstance(cis_modality.counts, pd.DataFrame):
             cis_counts = cis_modality.counts.loc[cis_feature].values
         else:
-            # numpy array - need to find index
+            # numpy/sparse array - need to find index
             feature_idx = cis_modality.feature_meta.index.get_loc(cis_feature)
             if cis_modality.cells_axis == 1:
                 cis_counts = cis_modality.counts[feature_idx, :]
             else:
                 cis_counts = cis_modality.counts[:, feature_idx]
+            # Densify if sparse (slicing sparse returns sparse row/col matrix)
+            if hasattr(cis_counts, 'toarray'):
+                cis_counts = cis_counts.toarray().ravel()
 
         # convert to gpu for fitting
         if self.model.alpha_x_prefit is not None and self.model.alpha_x_prefit.device != self.model.device:

--- a/bayesDREAM/fitting/technical.py
+++ b/bayesDREAM/fitting/technical.py
@@ -696,8 +696,10 @@ class TechnicalFitter:
                     f"Cannot perform cis modeling with '{distribution}' distribution."
                 )
 
-        # Always use the modality's filtered counts directly
+        # Always use the modality's filtered counts directly (densify if sparse)
         counts_to_fit = modality.counts
+        if hasattr(counts_to_fit, 'toarray'):
+            counts_to_fit = counts_to_fit.toarray()
         if modality.cell_names is not None:
             modality_cells = modality.cell_names
         else:

--- a/bayesDREAM/fitting/technical.py
+++ b/bayesDREAM/fitting/technical.py
@@ -696,25 +696,36 @@ class TechnicalFitter:
                     f"Cannot perform cis modeling with '{distribution}' distribution."
                 )
 
-        # For primary modality, use original counts (includes cis gene)
-        # For other modalities, use modality counts
-        if modality_name == self.model.primary_modality and hasattr(self.model, 'counts'):
-            # Use original counts which include the cis gene
-            if isinstance(self.model.counts, pd.DataFrame):
-                counts_to_fit = self.model.counts.values
-                # Cell names from the DataFrame columns
-                modality_cells = self.model.counts.columns.tolist()
-            else:
-                counts_to_fit = self.model.counts
-                # Fall back to meta cells
-                modality_cells = self.model.meta['cell'].values[:counts_to_fit.shape[modality.cells_axis]]
-            print(f"[INFO] Using original counts for primary modality '{modality_name}' (includes cis gene if present)")
+        # Always use the modality's filtered counts directly
+        counts_to_fit = modality.counts
+        if modality.cell_names is not None:
+            modality_cells = modality.cell_names
         else:
-            counts_to_fit = modality.counts
-            if modality.cell_names is not None:
-                modality_cells = modality.cell_names
+            modality_cells = self.model.meta['cell'].values[:counts_to_fit.shape[modality.cells_axis]]
+
+        # Track number of trans features; we may append the cis gene row below
+        n_trans_features = modality.dims['n_features']
+        cis_idx_in_counts = None  # set if cis gene is appended as last row
+
+        # For primary modality with a cis gene: append the cis gene row so we can
+        # estimate alpha_x_prefit from the technical fit (NTC cells only).
+        if (modality_name == self.model.primary_modality
+                and self.model.cis_gene is not None
+                and 'cis' in self.model.modalities):
+            cis_mod = self.model.get_modality('cis')
+            # cis modality has cells_axis=1, so counts is [1, N]
+            cis_row = cis_mod.counts if cis_mod.cells_axis == 1 else cis_mod.counts.T
+
+            if sparse.issparse(counts_to_fit):
+                cis_row_sp = (cis_row.tocsr() if sparse.issparse(cis_row)
+                              else sparse.csr_matrix(np.asarray(cis_row).reshape(1, -1)))
+                counts_to_fit = sparse.vstack([counts_to_fit, cis_row_sp], format='csr')
             else:
-                modality_cells = self.model.meta['cell'].values[:counts_to_fit.shape[modality.cells_axis]]
+                cis_row_dense = np.asarray(cis_row).reshape(1, -1)
+                counts_to_fit = np.vstack([np.asarray(counts_to_fit), cis_row_dense])
+
+            cis_idx_in_counts = n_trans_features  # cis gene is the last row
+            print(f"[INFO] Appended cis gene '{self.model.cis_gene}' for alpha_x estimation")
 
         # CRITICAL: Convert numpy.matrix to numpy.ndarray if needed
         # numpy.matrix is deprecated and has problematic indexing behavior with boolean arrays
@@ -1979,59 +1990,24 @@ class TechnicalFitter:
         # ----------------------------------------
         # Feature metadata flags
         # ----------------------------------------
-        # Determine where masks were computed from (based on counts_to_fit source)
-        # If we used self.model.counts, masks correspond to those features
-        # If we used modality.counts, masks correspond to modality features
-        # Did we use self.model.counts as the source for counts_to_fit?
-        used_original_counts = (
-            modality_name == self.model.primary_modality
-            and hasattr(self.model, "counts")
-        )
-        
-        if used_original_counts:
-            # Masks are for original counts features - store in base class
-            if isinstance(self.model.counts, pd.DataFrame):
-                index = self.model.counts.index
-            else:
-                # No natural index => just use a RangeIndex of the right length
-                index = pd.RangeIndex(len(zero_count_mask))
-        
-            if not hasattr(self.model, "counts_meta"):
-                self.model.counts_meta = pd.DataFrame(index=index)
-            elif len(self.model.counts_meta) != len(zero_count_mask):
-                # Realign counts_meta if needed
-                self.model.counts_meta = self.model.counts_meta.reindex(index)
-        
-            self.model.counts_meta["ntc_zero_count"]            = zero_count_mask
-            self.model.counts_meta["ntc_zero_std"]              = zero_std_mask
-            self.model.counts_meta["ntc_single_category"]       = only_one_category_mask
-            self.model.counts_meta["ntc_excluded_from_fit"]     = needs_exclusion_mask
-            self.model.counts_meta["technical_correction_applied"] = ~needs_exclusion_mask
-        
-        else:
-            # Masks are for modality features - store in modality metadata
-            if len(zero_count_mask) != len(modality.feature_meta):
-                raise ValueError(
-                    f"Mask length mismatch: masks have {len(zero_count_mask)} elements "
-                    f"but modality.feature_meta has {len(modality.feature_meta)} rows. "
-                    f"This likely means counts_to_fit and modality.counts have different feature counts."
-                )
-            modality.feature_meta["ntc_zero_count"]            = zero_count_mask.tolist()
-            modality.feature_meta["ntc_zero_std"]              = zero_std_mask.tolist()
-            modality.feature_meta["ntc_single_category"]       = only_one_category_mask.tolist()
-            modality.feature_meta["ntc_excluded_from_fit"]     = needs_exclusion_mask.tolist()
-            modality.feature_meta["technical_correction_applied"] = (~needs_exclusion_mask).tolist()
+        # Masks cover rows 0..n_trans_features-1 (trans genes) and optionally
+        # row n_trans_features (cis gene, if appended).  Store only the trans
+        # portion in the modality's feature_meta.
+        if len(modality.feature_meta) == n_trans_features:
+            modality.feature_meta["ntc_zero_count"]               = zero_count_mask[:n_trans_features].tolist()
+            modality.feature_meta["ntc_zero_std"]                 = zero_std_mask[:n_trans_features].tolist()
+            modality.feature_meta["ntc_single_category"]          = only_one_category_mask[:n_trans_features].tolist()
+            modality.feature_meta["ntc_excluded_from_fit"]        = needs_exclusion_mask[:n_trans_features].tolist()
+            modality.feature_meta["technical_correction_applied"] = (~needs_exclusion_mask[:n_trans_features]).tolist()
 
     
         # ----------------------------------------
         # Persist results at modality level
         # ----------------------------------------
-        # For primary modality fitted with original counts (includes cis gene),
-        # we need to extract alpha_x for the cis gene and exclude it from modality alpha_y.
-        if modality_name == self.model.primary_modality and hasattr(self.model, 'counts') and \
-           self.model.cis_gene is not None and 'cis' in self.model.modalities:
+        if cis_idx_in_counts is not None:
+            # Cis gene was appended as the last row.  Extract its alpha for alpha_x_prefit,
+            # then trim it from all primary-modality posteriors so they align with the modality.
 
-            # Enforce: cis effect must NOT be multinomial
             if distribution == 'multinomial':
                 raise ValueError(
                     "Primary modality uses a multinomial distribution, "
@@ -2039,123 +2015,77 @@ class TechnicalFitter:
                     "Ensure the primary modality is not multinomial when cis is present."
                 )
 
-            # Check if cis gene is in the original counts
-            if isinstance(self.model.counts, pd.DataFrame) and self.model.cis_gene in self.model.counts.index:
-                all_genes_orig = self.model.counts.index.tolist()
-                cis_idx_orig = all_genes_orig.index(self.model.cis_gene)
+            full_alpha_y_mult = posterior_samples["alpha_y_mult"]
+            full_alpha_y_add  = posterior_samples["alpha_y_add"]
 
-                # Expect alpha_y_mult and alpha_y_add to be [S?, C, T_all] for non-multinomial primary
-                full_alpha_y_mult = posterior_samples["alpha_y_mult"]
-                full_alpha_y_add  = posterior_samples["alpha_y_add"]
+            if full_alpha_y_mult is None:
+                raise RuntimeError(
+                    "alpha_y_mult is None while attempting cis extraction. "
+                    "This can happen if the distribution is multinomial; "
+                    "check distribution handling earlier."
+                )
 
-                if full_alpha_y_mult is None:
-                    raise RuntimeError(
-                        "alpha_y_mult is None while attempting cis extraction. "
-                        "This can happen if the distribution is multinomial; "
-                        "check distribution handling earlier."
-                    )
+            cis_idx_orig = cis_idx_in_counts          # always == n_trans_features
+            trans_idx    = list(range(cis_idx_orig))  # 0 .. n_trans_features-1
+            T_all_with_cis = n_trans_features + 1
 
-                if cis_idx_orig < full_alpha_y_mult.shape[-1]:
-                    # Extract cis gene alpha (mean over samples → [C])
-                    self.model.alpha_x_prefit = full_alpha_y_mult[..., cis_idx_orig].mean(dim=0)
+            # alpha_x_prefit: mean over posterior samples → [C]
+            self.model.alpha_x_prefit = full_alpha_y_mult[..., cis_idx_orig].mean(dim=0)
 
-                    # Exclude cis from modality alpha_y
-                    all_idx = list(range(full_alpha_y_mult.shape[-1]))
-                    trans_idx = [i for i in all_idx if i != cis_idx_orig]
-
-                    # Store mean over samples → [C, T]
-                    if modality.distribution == 'negbinom':
-                        modality.alpha_y_prefit_mult = full_alpha_y_mult[..., trans_idx].mean(dim=0)
-                        # Don't set alpha_y_prefit_add for negbinom
-                    else:  # binomial, multinomial, normal, studentt use additive
-                        modality.alpha_y_prefit_add = full_alpha_y_add[..., trans_idx].mean(dim=0)
-                        # Don't set alpha_y_prefit_mult for additive modalities
-
-                    # ========================================
-                    # Extract cis gene posterior samples and store in cis modality
-                    # ========================================
-                    cis_modality = self.model.get_modality('cis')
-                    cis_posterior = {}
-
-                    # Extract raw sampled parameters for cis gene
-                    if 'log2_alpha_y' in posterior_samples:
-                        cis_posterior['log2_alpha_x'] = posterior_samples['log2_alpha_y'][..., cis_idx_orig:cis_idx_orig+1]
-
-                    if 'alpha_y_mul' in posterior_samples:
-                        cis_posterior['alpha_x_mul'] = posterior_samples['alpha_y_mul'][..., cis_idx_orig:cis_idx_orig+1]
-
-                    if 'delta_y_add' in posterior_samples:
-                        cis_posterior['delta_x_add'] = posterior_samples['delta_y_add'][..., cis_idx_orig:cis_idx_orig+1]
-
-                    if 'o_y' in posterior_samples:
-                        cis_posterior['o_x'] = posterior_samples['o_y'][..., cis_idx_orig:cis_idx_orig+1]
-
-                    if 'mu_ntc' in posterior_samples:
-                        cis_posterior['mu_ntc'] = posterior_samples['mu_ntc'][..., cis_idx_orig:cis_idx_orig+1]
-
-                    # Create reconstructed alpha with baseline (matching what we do for alpha_y)
-                    # These already have shape [S, C-1, 1] from the extraction above
-                    if 'alpha_x_mul' in cis_posterior:
-                        alpha_x_mul_raw = cis_posterior['alpha_x_mul']  # [S, C-1, 1]
-                        # Add baseline (C=1) dimension
-                        if alpha_x_mul_raw.dim() == 3:
-                            S, Cminus1, _ = alpha_x_mul_raw.shape
-                            cis_posterior['alpha_x_mult'] = torch.cat(
-                                [torch.ones(S, 1, 1, device=alpha_x_mul_raw.device), alpha_x_mul_raw],
-                                dim=1
-                            )  # [S, C, 1]
-                        cis_posterior['alpha_x'] = cis_posterior['alpha_x_mult']  # alias
-
-                    if 'delta_x_add' in cis_posterior:
-                        delta_x_add_raw = cis_posterior['delta_x_add']  # [S, C-1, 1]
-                        # Add baseline (C=0) dimension
-                        if delta_x_add_raw.dim() == 3:
-                            S, Cminus1, _ = delta_x_add_raw.shape
-                            cis_posterior['alpha_x_add'] = torch.cat(
-                                [torch.zeros(S, 1, 1, device=delta_x_add_raw.device), delta_x_add_raw],
-                                dim=1
-                            )  # [S, C, 1]
-
-                    # Store in cis modality
-                    cis_modality.posterior_samples_technical = cis_posterior
-                    print(f"[INFO] Stored cis gene posterior samples in 'cis' modality: {list(cis_posterior.keys())}")
-
-                    # ========================================
-                    # Exclude cis gene from ALL primary modality posterior samples
-                    # ========================================
-                    # Store full posteriors (not means) in posterior_samples dict
-                    if modality.distribution == 'negbinom':
-                        posterior_samples["alpha_y_mult"] = full_alpha_y_mult[..., trans_idx]
-                        posterior_samples["alpha_y"] = posterior_samples["alpha_y_mult"]
-                    else:
-                        posterior_samples["alpha_y_add"] = full_alpha_y_add[..., trans_idx]
-                        posterior_samples["alpha_y"] = posterior_samples["alpha_y_add"]
-
-                    # CRITICAL: Also exclude cis gene from ALL raw posterior samples
-                    # These raw samples are used for analysis/diagnostics, so they must match gene modality
-                    for key in ['log2_alpha_y', 'alpha_y_mul', 'delta_y_add', 'o_y', 'mu_ntc']:
-                        if key in posterior_samples:
-                            raw_sample = posterior_samples[key]
-                            # These are typically [S, C-1, T] or [S, 1, T] depending on the parameter
-                            if raw_sample is not None and raw_sample.shape[-1] == len(all_genes_orig):
-                                posterior_samples[key] = raw_sample[..., trans_idx]
-                                print(f"[INFO] Excluded cis gene from '{key}': {raw_sample.shape} -> {posterior_samples[key].shape}")
-
-                    print(f"[INFO] Extracted alpha_x for cis '{self.model.cis_gene}' and excluded it from ALL primary modality posterior samples")
-                else:
-                    # Cis gene not present after filtering; store mean
-                    if modality.distribution == 'negbinom':
-                        modality.alpha_y_prefit_mult = posterior_samples["alpha_y_mult"].mean(dim=0)
-                    else:
-                        modality.alpha_y_prefit_add = posterior_samples["alpha_y_add"].mean(dim=0)
+            # Modality alpha_y: trans genes only → mean → [C, T]
+            if modality.distribution == 'negbinom':
+                modality.alpha_y_prefit_mult = full_alpha_y_mult[..., trans_idx].mean(dim=0)
             else:
-                # Cis gene not in counts; store mean
-                if modality.distribution == 'negbinom':
-                    modality.alpha_y_prefit_mult = posterior_samples["alpha_y_mult"].mean(dim=0)
-                else:
-                    modality.alpha_y_prefit_add = posterior_samples["alpha_y_add"].mean(dim=0)
+                modality.alpha_y_prefit_add = full_alpha_y_add[..., trans_idx].mean(dim=0)
+
+            # ---- Store cis gene posteriors in cis modality ----
+            cis_modality = self.model.get_modality('cis')
+            cis_posterior = {}
+            for src_key, dst_key in [
+                ('log2_alpha_y', 'log2_alpha_x'), ('alpha_y_mul', 'alpha_x_mul'),
+                ('delta_y_add', 'delta_x_add'),   ('o_y',         'o_x'),
+                ('mu_ntc',      'mu_ntc'),
+            ]:
+                if src_key in posterior_samples:
+                    cis_posterior[dst_key] = posterior_samples[src_key][..., cis_idx_orig:cis_idx_orig+1]
+
+            if 'alpha_x_mul' in cis_posterior:
+                raw = cis_posterior['alpha_x_mul']  # [S, C-1, 1]
+                if raw.dim() == 3:
+                    S, Cminus1, _ = raw.shape
+                    cis_posterior['alpha_x_mult'] = torch.cat(
+                        [torch.ones(S, 1, 1, device=raw.device), raw], dim=1)
+                    cis_posterior['alpha_x'] = cis_posterior['alpha_x_mult']
+
+            if 'delta_x_add' in cis_posterior:
+                raw = cis_posterior['delta_x_add']  # [S, C-1, 1]
+                if raw.dim() == 3:
+                    S, Cminus1, _ = raw.shape
+                    cis_posterior['alpha_x_add'] = torch.cat(
+                        [torch.zeros(S, 1, 1, device=raw.device), raw], dim=1)
+
+            cis_modality.posterior_samples_technical = cis_posterior
+            print(f"[INFO] Stored cis gene posteriors in 'cis' modality: {list(cis_posterior.keys())}")
+
+            # ---- Trim cis gene from ALL primary-modality posteriors ----
+            if modality.distribution == 'negbinom':
+                posterior_samples["alpha_y_mult"] = full_alpha_y_mult[..., trans_idx]
+                posterior_samples["alpha_y"]      = posterior_samples["alpha_y_mult"]
+            else:
+                posterior_samples["alpha_y_add"] = full_alpha_y_add[..., trans_idx]
+                posterior_samples["alpha_y"]     = posterior_samples["alpha_y_add"]
+
+            for key in ['log2_alpha_y', 'alpha_y_mul', 'delta_y_add', 'o_y', 'mu_ntc']:
+                if key in posterior_samples and isinstance(posterior_samples[key], torch.Tensor):
+                    v = posterior_samples[key]
+                    if v.shape[-1] == T_all_with_cis:
+                        posterior_samples[key] = v[..., trans_idx]
+
+            print(f"[INFO] Extracted alpha_x for '{self.model.cis_gene}' (index {cis_idx_orig}) "
+                  f"and trimmed it from primary modality posteriors")
+
         else:
-            # Not primary modality or no cis gene, store mean
+            # No cis gene appended (non-primary modality, or no cis_gene set)
             if modality.distribution == 'negbinom':
                 modality.alpha_y_prefit_mult = posterior_samples["alpha_y_mult"].mean(dim=0)
             else:

--- a/bayesDREAM/fitting/trans.py
+++ b/bayesDREAM/fitting/trans.py
@@ -1439,8 +1439,10 @@ class TransFitter:
                 f"Please run fit_technical(modality_name='{modality_name}') first."
             )
 
-        # Get counts from modality
+        # Get counts from modality (densify if sparse)
         counts_to_fit = modality.counts
+        if hasattr(counts_to_fit, 'toarray'):
+            counts_to_fit = counts_to_fit.toarray()
 
         # Get cell names from modality
         if modality.cell_names is not None:

--- a/bayesDREAM/io/save.py
+++ b/bayesDREAM/io/save.py
@@ -146,7 +146,10 @@ class ModelSaver:
                         posterior_clean['alpha_y_mult'] = mod.alpha_y_prefit_mult
 
                 # Add feature metadata (including full DataFrame for excluded features tracking)
-                n_features = mod.dims.get('n_features', None)
+                # Use actual tensor shape (not modality dims which may differ after filtering)
+                _sample_tensor = next((v for v in posterior_clean.values()
+                                       if isinstance(v, torch.Tensor) and v.ndim >= 2), None)
+                n_features = _sample_tensor.shape[-1] if _sample_tensor is not None else mod.dims.get('n_features', None)
                 posterior_with_meta = {
                     'posterior_samples': posterior_clean,
                     'modality_name': mod_name,
@@ -312,12 +315,17 @@ class ModelSaver:
                 primary_mod = self.model.get_modality(self.model.primary_modality)
 
                 # Add modality and feature metadata (including full feature_meta DataFrame)
+                # Use actual tensor shape (not modality dims which may differ after filtering)
+                _sample_tensor = next((v for v in posterior_clean.values()
+                                       if isinstance(v, torch.Tensor) and v.ndim >= 2), None)
+                n_features_primary = (_sample_tensor.shape[-1] if _sample_tensor is not None
+                                      else primary_mod.dims.get('n_features', None))
                 posterior_with_meta = {
                     'posterior_samples': posterior_clean,
                     'modality_name': self.model.primary_modality,
                     'distribution': primary_mod.distribution,
                     'feature_names': primary_mod.feature_names if hasattr(primary_mod, 'feature_names') else None,
-                    'n_features': primary_mod.dims.get('n_features', None),
+                    'n_features': n_features_primary,
                     'feature_meta': primary_mod.feature_meta.to_dict('records') if hasattr(primary_mod, 'feature_meta') and primary_mod.feature_meta is not None else None,
                     'cis_gene': self.model.cis_gene,
                     'losses_trans': self.model.losses_trans if hasattr(self.model, 'losses_trans') else None,
@@ -329,7 +337,7 @@ class ModelSaver:
                 torch.save(posterior_with_meta, path)
                 saved_files['posterior_samples_trans'] = path
                 if verbose:
-                    print(f"[SAVE] posterior_samples_trans (modality: {self.model.primary_modality}, {primary_mod.dims.get('n_features')} features) → {path}")
+                    print(f"[SAVE] posterior_samples_trans (modality: {self.model.primary_modality}, {n_features_primary} features) → {path}")
 
         # Save per-modality posterior samples
         for mod_name in modalities_to_save:
@@ -338,7 +346,10 @@ class ModelSaver:
                 posterior_clean = {k: v for k, v in mod.posterior_samples_trans.items()
                                  if k not in ['y_obs', 'x_obs']}
 
-                n_features = mod.dims.get('n_features', None)
+                # Use actual tensor shape (not modality dims which may differ after filtering)
+                _sample_tensor = next((v for v in posterior_clean.values()
+                                       if isinstance(v, torch.Tensor) and v.ndim >= 2), None)
+                n_features = _sample_tensor.shape[-1] if _sample_tensor is not None else mod.dims.get('n_features', None)
 
                 # Add modality and feature metadata (including full feature_meta DataFrame)
                 posterior_with_meta = {

--- a/bayesDREAM/io/summary.py
+++ b/bayesDREAM/io/summary.py
@@ -1203,9 +1203,27 @@ class ModelSummarizer:
                 raw_counts_mean.append(np.nan)
 
         # Build guide-level DataFrame
+        # 'target' column may be absent in high MOI mode when guide_targets_dict is used;
+        # fall back to deriving the primary target from guide_targets_dict.
+        if 'target' in guide_meta.columns:
+            guide_targets_col = guide_meta['target'].values
+        elif hasattr(self.model, 'guide_targets_dict') and self.model.guide_targets_dict:
+            _ntc_variants = {'ntc', 'NTC', 'non-targeting', 'non-targeting-control', 'Non-Targeting'}
+            def _primary(g):
+                ts = self.model.guide_targets_dict.get(g, [])
+                if self.model.cis_gene and self.model.cis_gene in ts:
+                    return self.model.cis_gene
+                for t in ts:
+                    if t in _ntc_variants:
+                        return 'ntc'
+                return ts[0] if ts else 'unknown'
+            guide_targets_col = [_primary(g) for g in guides]
+        else:
+            guide_targets_col = ['unknown'] * len(guides)
+
         guide_df = pd.DataFrame({
             'guide': guides,
-            'target': guide_meta['target'].values,
+            'target': guide_targets_col,
             'n_cells': guide_meta['n_cells'].values,
             'x_true_mean': x_true_mean,
             'x_true_lower': x_true_lower,

--- a/tests/test_gene_meta.py
+++ b/tests/test_gene_meta.py
@@ -23,7 +23,12 @@ def _make_base_data():
 
 
 class TestGeneMeta(unittest.TestCase):
-    """Verify gene metadata handling at model initialisation."""
+    """Verify gene metadata handling at model initialisation.
+
+    After the refactoring, gene metadata lives in the gene modality's
+    feature_meta (model.get_modality('gene').feature_meta), not on the
+    model object directly.
+    """
 
     @classmethod
     def setUpClass(cls):
@@ -40,10 +45,14 @@ class TestGeneMeta(unittest.TestCase):
             **kwargs,
         )
 
+    def _gene_feature_meta(self, model):
+        return model.get_modality('gene').feature_meta
+
     def test_no_gene_meta_creates_minimal_metadata(self):
         model = self._make_model(label='test_no_meta')
-        self.assertIsNotNone(model.gene_meta)
-        self.assertGreater(model.gene_meta.shape[0], 0)
+        fm = self._gene_feature_meta(model)
+        self.assertIsNotNone(fm)
+        self.assertGreater(fm.shape[0], 0)
 
     def test_full_gene_meta_accepted(self):
         gene_meta = pd.DataFrame({
@@ -54,14 +63,15 @@ class TestGeneMeta(unittest.TestCase):
             'biotype': ['protein_coding'] * 11,
         }, index=[f'GENE{i}' for i in range(10)] + ['GFI1B'])
         model = self._make_model(feature_meta=gene_meta, label='test_with_meta')
-        self.assertIn('gene', model.gene_meta.columns)
+        self.assertIn('gene', self._gene_feature_meta(model).columns)
 
     def test_gene_meta_with_gene_name_only(self):
         gene_meta_simple = pd.DataFrame({
             'gene_name': [f'GENE{i}' for i in range(10)] + ['GFI1B'],
         }, index=[f'GENE{i}' for i in range(10)] + ['GFI1B'])
         model = self._make_model(feature_meta=gene_meta_simple, label='test_simple_meta')
-        self.assertIn('gene', model.gene_meta.columns, "'gene' column should be created from 'gene_name'")
+        fm = self._gene_feature_meta(model)
+        self.assertIn('gene_name', fm.columns, "'gene_name' column should be present")
 
     def test_gene_meta_index_becomes_gene_column(self):
         gene_meta_indexed = pd.DataFrame({
@@ -71,7 +81,8 @@ class TestGeneMeta(unittest.TestCase):
         gene_meta_indexed.index = [f'GENE{i}' for i in range(10)] + ['GFI1B']
         gene_meta_indexed.index.name = 'gene_symbol'
         model = self._make_model(feature_meta=gene_meta_indexed, label='test_indexed_meta')
-        self.assertIn('gene', model.gene_meta.columns, "'gene' column should be created from index")
+        fm = self._gene_feature_meta(model)
+        self.assertIn('gene_name', fm.columns, "'gene_name' column should be present")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previous merge missed some high MOI fixes:
  ## Summary

  - **Use modality counts in `fit_technical`**: switched from `self.model.counts`
    (now None) to `modality.counts` directly; removes `self.gene_meta` and
    `self._gene_names` (gene metadata now lives exclusively in the gene modality's
    `feature_meta`)
  - **High MOI `guide_meta['target']` fixes**: multiple code paths assumed
    `guide_meta` had a `'target'` column, which doesn't exist in many-to-many
    high MOI mode. Fixed in `fit_cis` (`independent_mu_sigma`), `adjust_ntc_sum_factor`,
    `_model_x` (NTC mask), and `cis_guide_summary`; all now fall back to
    `guide_targets_dict`
  - **NTC mask pre-computation**: `_model_x` was rebuilding the NTC guide mask from
    pandas on every SVI forward pass; now pre-computed once before the SVI loop
  - **Sparse count support**: `torch.tensor()` cannot consume scipy sparse arrays;
    added `.toarray()` densification guards in `fit_technical`, `fit_cis`, and
    `fit_trans`

  ## Test plan

  - [ ] Run full pipeline (technical → cis → trans) in high MOI mode with `guide_target` DataFrame
  - [ ] Verify `fit_trans` works when modality counts are stored as scipy sparse matrices
  - [ ] Confirm `model.get_modality('gene').feature_meta` is the sole source of gene metadata